### PR TITLE
Ensure LabelList generic extends Data interface

### DIFF
--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -25,9 +25,9 @@ interface LabelListProps<T extends Data> {
   formatter?: Function;
 }
 
-export type Props<T> = SVGProps<SVGElement> & LabelListProps<T>;
+export type Props<T extends Data> = SVGProps<SVGElement> & LabelListProps<T>;
 
-export type ImplicitLabelListType<T> =
+export type ImplicitLabelListType<T extends Data> =
   | boolean
   | ReactElement<SVGElement>
   | ((props: any) => ReactElement<SVGElement>)


### PR DESCRIPTION
Introducing fix by @stianjensen until main library recharts is able to compile without errors.
Original fix is in @[stianjensen](https://github.com/mikonboard/recharts/commits?author=stianjensen)
stianjensen/recharts:patch-1
